### PR TITLE
Drain input buffer before rendering.

### DIFF
--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/Cli.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/Cli.java
@@ -167,8 +167,12 @@ public class Cli {
 			long time = System.currentTimeMillis();
 
 			while (running) {
-				final KeyStroke key = terminal.pollInput();
-				final boolean keyHandled = handleGlobalInput(key);
+				KeyStroke key;
+				boolean keyHandled = false;
+
+				while ((key = terminal.pollInput()) != null) {
+					keyHandled |= handleGlobalInput(key);
+				}
 
 				if (screen.doResizeIfNecessary() != null || System.currentTimeMillis() - time > FRAME_TIME_MS || keyHandled) {
 					time = System.currentTimeMillis();


### PR DESCRIPTION
Resolves #2.

### Description

This PR fixes the bug that the input buffer was only drained one character per frame, resulting in slow input processing, especially noticeable when pasting text.
The solution is to drain the entire input buffer and process all characters before proceeding to draw the next frame.