### PR TITLE
Intercept intercept j/k, h/l keys in text area

### DIFF
--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/api/widget/TextArea.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/api/widget/TextArea.java
@@ -852,6 +852,26 @@ public class TextArea extends InteractableBase {
 			switch (key.getKeyType()) {
 				case Character -> {
 					switch (key.getCharacter()) {
+						case 'k' -> {
+							if (moveUp()) {
+								return InputResult.HANDLED;
+							}
+						}
+						case 'j' -> {
+							if (moveDown()) {
+								return InputResult.HANDLED;
+							}
+						}
+						case 'h' -> {
+							if (moveLeft()) {
+								return InputResult.HANDLED;
+							}
+						}
+						case 'l' -> {
+							if (moveRight()) {
+								return InputResult.HANDLED;
+							}
+						}
 						case 'I' -> {
 							moveToLineStart();
 							return InputResult.ENTER_EDIT_MODE;


### PR DESCRIPTION
Resolves #4.

### Description

Previously, <kbd>j</kbd> / <kbd>k</kbd>, <kbd>h</kbd> / <kbd>l</kbd> were not handled by the text area, so they were handled by default navigation. Now they're actually intercepted and can be used to scroll through the text.