### PR TITLE
Installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ You can verify your Java version by running `java --version` in your terminal.
    > Note that on Windows you'll have to use `javaw` because running it directly in the Terminal usually causes
    > problems. By doing so, an emulated terminal window will be launched that allows the app to work properly.
 
+### Installation script
+
+If you don't want to manually startup the `*.jar` file, you can use the install scripts that download the latest
+Kinote version and create a global `kinote` command to launch the TUI from anywhere.
+
+**Linux/macOS:**
+```bash
+curl -sSL https://raw.githubusercontent.com/SomeSourceCode/kinote/main/install.sh | bash
+```
+
+**Windows:**
+```bash
+irm https://raw.githubusercontent.com/SomeSourceCode/kinote/main/install.ps1 | iex
+```
+
 ## How does it work?
 
 The application is a TUI (Terminal User Interface) that operates in three distinct modes.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,26 @@
+$InstallDir = "$env:USERPROFILE\.kinote\bin"
+$JarUrl = "https://github.com/SomeSourceCode/kinote/releases/latest/download/kinote.jar"
+
+Write-Host "Downloading Kinote..."
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+# download latest jar
+Invoke-WebRequest -Uri $JarUrl -OutFile "$InstallDir\kinote.jar"
+
+Write-Host "Creating executable wrapper..."
+# create a batch file that forwards all arguments (%*)
+$BatchContent = "@echo off`njavaw -jar `"$InstallDir\kinote.jar`" %*"
+Set-Content -Path "$InstallDir\kinote.bat" -Value $BatchContent
+
+Write-Host "Checking system PATH..."
+$UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+
+# add to PATH if missing
+if ($UserPath -notmatch [regex]::Escape($InstallDir)) {
+    $NewPath = "$UserPath;$InstallDir"
+    [Environment]::SetEnvironmentVariable("PATH", $NewPath, "User")
+    Write-Host "Kinote installed! Added to your PATH."
+    Write-Host "Please restart your terminal to use the 'kinote' command."
+} else {
+    Write-Host "Kinote installed successfully!"
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+INSTALL_DIR="$HOME/.kinote/bin"
+WRAPPER_DIR="$HOME/.local/bin"
+JAR_URL="https://github.com/SomeSourceCode/kinote/releases/latest/download/kinote.jar"
+
+echo "Downloading Kinote..."
+mkdir -p "$INSTALL_DIR"
+mkdir -p "$WRAPPER_DIR"
+
+# download latest jar
+curl -sSL "$JAR_URL" -o "$INSTALL_DIR/kinote.jar"
+
+echo "Creating executable wrapper..."
+# write wrapper script
+cat << 'EOF' > "$WRAPPER_DIR/kinote"
+#!/bin/bash
+java -jar "$HOME/.kinote/bin/kinote.jar" "$@"
+EOF
+
+# make wrapper executable that forwards all arguments ($@)
+chmod +x "$WRAPPER_DIR/kinote"
+
+echo "Kinote installed successfully!"
+
+# Check if WRAPPER_DIR is in the current PATH
+if [[ ":$PATH:" != *":$WRAPPER_DIR:"* ]]; then
+  echo ""
+  echo "==========================================================="
+  echo "  WARNING: $WRAPPER_DIR is not in your PATH."
+  echo "  You must add it to run 'kinote' globally."
+  echo ""
+  echo "  For Zsh, run:"
+  echo "  echo 'export PATH=\"$WRAPPER_DIR:\$PATH\"' >> ~/.zshrc"
+  echo ""
+  echo "  For Bash, run:"
+  echo "  echo 'export PATH=\"$WRAPPER_DIR:\$PATH\"' >> ~/.bashrc"
+  echo ""
+  echo "  Then restart your terminal or run 'source ~/.zshrc' or 'source ~/.bashrc' to apply the changes."
+  echo "==========================================================="
+fi


### PR DESCRIPTION
Resolves #9.

### Description

Instead of having to manually download and run the `*.jar`, users can now use the installation scripts that also register a global `kinote` command to launch the application:

**MacOS/Linux:**
```bash
curl -sSL https://raw.githubusercontent.com/SomeSourceCode/Kinote/main/install.sh | bash
```

**Windows:**
```bash
irm https://raw.githubusercontent.com/SomeSourceCode/Kinote/main/install.ps1 | iex
```