### PR TITLE
Refactor TMDb imports to use custom client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
 			<artifactId>gson</artifactId>
 			<version>2.13.2</version>
 		</dependency>
-        <dependency>
-            <groupId>uk.co.conoregan</groupId>
-            <artifactId>themoviedbapi</artifactId>
-            <version>2.4.0</version>
-        </dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp-jvm</artifactId>
+			<version>5.3.2</version>
+		</dependency>
 		<dependency>
 			<groupId>me.xdrop</groupId>
 			<artifactId>fuzzywuzzy</artifactId>

--- a/src/main/java/de/unistuttgart/einf/moviemanager/Main.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/Main.java
@@ -1,6 +1,7 @@
 package de.unistuttgart.einf.moviemanager;
 
 import de.unistuttgart.einf.moviemanager.cli.Cli;
+import de.unistuttgart.einf.moviemanager.dbimport.TmdbClient;
 import de.unistuttgart.einf.moviemanager.io.*;
 import de.unistuttgart.einf.moviemanager.model.Settings;
 import de.unistuttgart.einf.moviemanager.service.CommandHistoryService;
@@ -40,7 +41,9 @@ public class Main {
 		);
 		Runtime.getRuntime().addShutdownHook(new Thread(commandHistoryService::save));
 
-		new Cli(mediaService, settingsService, commandHistoryService).run();
+		final TmdbClient tmdbClient = new TmdbClient(() -> settingsService.getSettings().getTmdbApiKey());
+
+		new Cli(mediaService, settingsService, commandHistoryService, tmdbClient).run();
 	}
 
 }

--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/Cli.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/Cli.java
@@ -17,6 +17,7 @@ import de.unistuttgart.einf.moviemanager.cli.page.DetailsPage;
 import de.unistuttgart.einf.moviemanager.cli.page.OverviewPage;
 import de.unistuttgart.einf.moviemanager.cli.page.Page;
 import de.unistuttgart.einf.moviemanager.command.CommandDispatcher;
+import de.unistuttgart.einf.moviemanager.dbimport.TmdbClient;
 import de.unistuttgart.einf.moviemanager.model.*;
 import de.unistuttgart.einf.moviemanager.service.CommandHistoryService;
 import de.unistuttgart.einf.moviemanager.service.MediaService;
@@ -44,6 +45,8 @@ public class Cli {
 	private final SettingsService settingsService;
 	private final CommandHistoryService commandHistoryService;
 
+	private final TmdbClient tmdbClient;
+
 	// components
 	private final VerticalBorderPane mainContainer;
 	private final Text dateDisplay;
@@ -59,14 +62,14 @@ public class Cli {
 	private final Deque<Page> pageStack = new ArrayDeque<>();
 
 	/**
-	 * Constructs a new Cli for the given media service.
+	 * Constructs a new Cli for the given services and tmdb client.
 	 *
 	 * @param mediaService the media service
 	 * @param settingsService the settings service
 	 * @param commandHistoryService the command history service
-	 * @throws IllegalArgumentException if any service is null
+	 * @throws IllegalArgumentException if any service or the tmdb client is null
 	 */
-	public Cli(MediaService mediaService, SettingsService settingsService, CommandHistoryService commandHistoryService) {
+	public Cli(MediaService mediaService, SettingsService settingsService, CommandHistoryService commandHistoryService, TmdbClient tmdbClient) {
 		if (mediaService == null) {
 			throw new IllegalArgumentException("mediaService must be non-null");
 		}
@@ -79,6 +82,10 @@ public class Cli {
 			throw new IllegalArgumentException("commandHistoryService must be non-null");
 		}
 		this.commandHistoryService = commandHistoryService;
+		if (tmdbClient == null) {
+			throw new IllegalArgumentException("tmdbClient must be non-null");
+		}
+		this.tmdbClient = tmdbClient;
 
 		scene = new Scene();
 
@@ -240,6 +247,15 @@ public class Cli {
 	 */
 	public SettingsService getSettingsService() {
 		return settingsService;
+	}
+
+	/**
+	 * Returns the tmdb client.
+	 *
+	 * @return the tmdb client
+	 */
+	public TmdbClient getTmdbClient() {
+		return tmdbClient;
 	}
 
 	/**

--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/ImportCommand.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/ImportCommand.java
@@ -136,12 +136,12 @@ public class ImportCommand {
 	}
 
 	private static void performImportMovie(Cli cli, int tmdbId, Language language) {
-		final MovieImporter importer = createMovieImporter(getApiKey(cli));
+		final MovieImporter importer = createMovieImporter(cli);
 		importer.setLanguage(language);
 
-		final Movie movie = new Movie();
+		final Movie movie;
 		try {
-			importer.importData(movie, tmdbId);
+			movie = importer.create(tmdbId);
 		} catch (MediaImportException exception) {
 			throw Command.fail("Failed to import movie with id '" + tmdbId + "'. Is it the correct ID? Is it a movie? Do you have a stable internet connection?");
 		}
@@ -153,13 +153,12 @@ public class ImportCommand {
 	}
 
 	private static void performImportSeries(Cli cli, int tmdbId, Language language) {
-		final SeriesImporter importer = createSeriesImporter(getApiKey(cli));
+		final SeriesImporter importer = createSeriesImporter(cli);
 		importer.setLanguage(language);
 
-		final Series series = new Series();
+		final Series series;
 		try {
-			importer.importData(series, tmdbId);
-			cli.getMediaService().save();
+			series = importer.create(tmdbId);
 		} catch (MediaImportException exception) {
 			throw Command.fail("Failed to import series with id '" + tmdbId + "'. Is it the correct ID? Is it a series? Do you have a stable internet connection?");
 		}
@@ -175,12 +174,12 @@ public class ImportCommand {
 			throw Command.fail("Season " + seasonNumber + " already exists in series '" + series.getTitle() + "'.");
 		}
 
-		final SeasonImporter importer = createSeasonImporter(getApiKey(cli));
+		final SeasonImporter importer = createSeasonImporter(cli);
 		importer.setLanguage(language);
 
-		final Season season = new Season(seasonNumber);
+		final Season season;
 		try {
-			importer.importData(season, seriesTmdbId, seasonNumber);
+			season = importer.create(seriesTmdbId, seasonNumber);
 		} catch (MediaImportException exception) {
 			throw Command.fail("Failed to import season " + seasonNumber + " (Series ID: " + seriesTmdbId + ").");
 		}
@@ -199,22 +198,18 @@ public class ImportCommand {
 			throw Command.fail("Episode " + episodeNumber + " already exists in season " + seasonNumber + ".");
 		}
 
-		final EpisodeImporter importer = createEpisodeImporter(getApiKey(cli));
+		final EpisodeImporter importer = createEpisodeImporter(cli);
 		importer.setLanguage(language);
 
-		final Episode episode = new Episode(episodeNumber);
+		final Episode episode;
 		try {
-			importer.importData(episode, seriesTmdbId, seasonNumber, episodeNumber);
+			episode = importer.create(seriesTmdbId, seasonNumber, episodeNumber);
 		} catch (MediaImportException exception) {
 			throw Command.fail("Failed to import episode " + episodeNumber + " (S" + seasonNumber + ", Series ID: " + seriesTmdbId + ").");
 		}
 
 		season.addChild(episode);
 		cli.refresh();
-	}
-
-	private static String getApiKey(Cli cli) {
-		return cli.getSettingsService().getSettings().getTmdbApiKey();
 	}
 
 	private static Language getLanguage(ExecutionContext context, Cli cli) {
@@ -236,28 +231,28 @@ public class ImportCommand {
 		throw Command.fail("Target series could not be determined. Either specify it explicitly as an argument or open a series/season/episode to provide context.");
 	}
 
-	private static MovieImporter createMovieImporter(String apiKey) {
-		final MovieImporter movieImporter = new MovieImporter(apiKey);
+	private static MovieImporter createMovieImporter(Cli cli) {
+		final MovieImporter movieImporter = new MovieImporter(cli.getTmdbClient());
 		movieImporter.include(ImportableAttribute.values());
 		return movieImporter;
 	}
 
-	private static SeriesImporter createSeriesImporter(String apiKey) {
-		final SeriesImporter seriesImporter = new SeriesImporter(apiKey);
+	private static SeriesImporter createSeriesImporter(Cli cli) {
+		final SeriesImporter seriesImporter = new SeriesImporter(cli.getTmdbClient());
 		seriesImporter.include(ImportableAttribute.values());
-		seriesImporter.setSeasonImporter(createSeasonImporter(apiKey));
+		seriesImporter.setSeasonImporter(createSeasonImporter(cli));
 		return seriesImporter;
 	}
 
-	private static SeasonImporter createSeasonImporter(String apiKey) {
-		final SeasonImporter seasonImporter = new SeasonImporter(apiKey);
+	private static SeasonImporter createSeasonImporter(Cli cli) {
+		final SeasonImporter seasonImporter = new SeasonImporter(cli.getTmdbClient());
 		seasonImporter.include(ImportableAttribute.values());
-		seasonImporter.setEpisodeImporter(createEpisodeImporter(apiKey));
+		seasonImporter.setEpisodeImporter(createEpisodeImporter(cli));
 		return seasonImporter;
 	}
 
-	private static EpisodeImporter createEpisodeImporter(String apiKey) {
-		final EpisodeImporter episodeImporter = new EpisodeImporter(apiKey);
+	private static EpisodeImporter createEpisodeImporter(Cli cli) {
+		final EpisodeImporter episodeImporter = new EpisodeImporter(cli.getTmdbClient());
 		episodeImporter.include(ImportableAttribute.values());
 		return episodeImporter;
 	}

--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/SmartFillCommand.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/SmartFillCommand.java
@@ -35,10 +35,6 @@ public class SmartFillCommand {
 										.executes(context -> executeImportUrl(context, cli))))));
 	}
 
-	private static String getApiKey(Cli cli) {
-		return cli.getSettingsService().getSettings().getTmdbApiKey();
-	}
-
 	private static Language getLanguage(ExecutionContext context, Cli cli) {
 		return context.getOptional("language", Language.class)
 				.orElseGet(() -> cli.getSettingsService().getSettings().getImportLanguage());
@@ -115,11 +111,11 @@ public class SmartFillCommand {
 	}
 
 	private static void performSmartFillMovie(Cli cli, Movie movie, int tmdbId, Language language) {
-		final MovieImporter movieImporter = createMovieImporter(getApiKey(cli));
+		final MovieImporter movieImporter = createMovieImporter(cli);
 		movieImporter.setLanguage(language);
 
 		try {
-			movieImporter.importData(movie, tmdbId);
+			movieImporter.fill(movie, tmdbId);
 		} catch (MediaImportException e) {
 			throw Command.fail("Failed to fill movie '" + movie.getTitle() + "' from TMDb (id " + tmdbId + "). Is it the correct ID? Is it a movie? Do you have a stable internet connection?");
 		}
@@ -128,11 +124,11 @@ public class SmartFillCommand {
 	}
 
 	private static void performSmartFillSeries(Cli cli, Series series, int tmdbId, Language language) {
-		final SeriesImporter seriesImporter = createSeriesImporter(getApiKey(cli));
+		final SeriesImporter seriesImporter = createSeriesImporter(cli);
 		seriesImporter.setLanguage(language);
 
 		try {
-			seriesImporter.importData(series, tmdbId);
+			seriesImporter.fill(series, tmdbId);
 		} catch (MediaImportException e) {
 			throw Command.fail("Failed to fill series '" + series.getTitle() + "' from TMDb (id " + tmdbId + "). Is it the correct ID? Is it a series? Do you have a stable internet connection?");
 		}
@@ -146,11 +142,11 @@ public class SmartFillCommand {
 			throw Command.fail("Season " + seasonNumber + " does not exist in series '" + series.getTitle() + "'.");
 		}
 
-		final SeasonImporter seasonImporter = createSeasonImporter(getApiKey(cli));
+		final SeasonImporter seasonImporter = createSeasonImporter(cli);
 		seasonImporter.setLanguage(language);
 
 		try {
-			seasonImporter.importData(season, tmdbId, seasonNumber);
+			seasonImporter.fill(season, tmdbId, seasonNumber);
 		} catch (MediaImportException e) {
 			throw Command.fail("Failed to fill season " + seasonNumber + " of series '" + series.getTitle() + "' from TMDb (id " + tmdbId + "). Is it the correct ID? Do you have a stable internet connection?");
 		}
@@ -169,11 +165,11 @@ public class SmartFillCommand {
 			throw Command.fail("Episode " + episodeNumber + " of season " + seasonNumber + " does not exist in series '" + series.getTitle() + "'.");
 		}
 
-		final EpisodeImporter episodeImporter = createEpisodeImporter(getApiKey(cli));
+		final EpisodeImporter episodeImporter = createEpisodeImporter(cli);
 		episodeImporter.setLanguage(language);
 
 		try {
-			episodeImporter.importData(episode, tmdbId, seasonNumber, episodeNumber);
+			episodeImporter.fill(episode, tmdbId, seasonNumber, episodeNumber);
 		} catch (MediaImportException e) {
 			throw Command.fail("Failed to fill episode " + episodeNumber + " of season " + seasonNumber + " of series '" + series.getTitle() + "' from TMDb (id " + tmdbId + "). Is it the correct ID? Do you have a stable internet connection?");
 		}
@@ -181,28 +177,28 @@ public class SmartFillCommand {
 		cli.refresh();
 	}
 
-	private static MovieImporter createMovieImporter(String apiKey) {
-		final MovieImporter movieImporter = new MovieImporter(apiKey);
+	private static MovieImporter createMovieImporter(Cli cli) {
+		final MovieImporter movieImporter = new MovieImporter(cli.getTmdbClient());
 		movieImporter.include(ImportableAttribute.values());
 		return movieImporter;
 	}
 
-	private static SeriesImporter createSeriesImporter(String apiKey) {
-		final SeriesImporter seriesImporter = new SeriesImporter(apiKey);
+	private static SeriesImporter createSeriesImporter(Cli cli) {
+		final SeriesImporter seriesImporter = new SeriesImporter(cli.getTmdbClient());
 		seriesImporter.include(ImportableAttribute.values());
-		seriesImporter.setSeasonImporter(createSeasonImporter(apiKey));
+		seriesImporter.setSeasonImporter(createSeasonImporter(cli));
 		return seriesImporter;
 	}
 
-	private static SeasonImporter createSeasonImporter(String apiKey) {
-		final SeasonImporter seasonImporter = new SeasonImporter(apiKey);
+	private static SeasonImporter createSeasonImporter(Cli cli) {
+		final SeasonImporter seasonImporter = new SeasonImporter(cli.getTmdbClient());
 		seasonImporter.include(ImportableAttribute.values());
-		seasonImporter.setEpisodeImporter(createEpisodeImporter(apiKey));
+		seasonImporter.setEpisodeImporter(createEpisodeImporter(cli));
 		return seasonImporter;
 	}
 
-	private static EpisodeImporter createEpisodeImporter(String apiKey) {
-		final EpisodeImporter episodeImporter = new EpisodeImporter(apiKey);
+	private static EpisodeImporter createEpisodeImporter(Cli cli) {
+		final EpisodeImporter episodeImporter = new EpisodeImporter(cli.getTmdbClient());
 		episodeImporter.include(ImportableAttribute.values());
 		return episodeImporter;
 	}

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/EpisodeImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/EpisodeImporter.java
@@ -1,149 +1,91 @@
 package de.unistuttgart.einf.moviemanager.dbimport;
 
+import com.google.gson.JsonObject;
 import de.unistuttgart.einf.moviemanager.model.Episode;
 import de.unistuttgart.einf.moviemanager.model.age.AgeRating;
 import de.unistuttgart.einf.moviemanager.model.age.RatingSystem;
-import info.movito.themoviedbapi.TmdbTvEpisodes;
-import info.movito.themoviedbapi.model.tv.episode.TvEpisodeDb;
-import info.movito.themoviedbapi.model.tv.season.TvSeasonEpisode;
-import info.movito.themoviedbapi.tools.TmdbException;
 
 import java.util.Set;
 import java.util.regex.Pattern;
 
-public class EpisodeImporter extends MediaImporter {
+/**
+ * Used to import episode data from TMDb.
+ */
+public class EpisodeImporter extends MediaImporter<Episode> {
 
 	private static final Pattern TITLE_PREFIX_PATTERN = Pattern.compile("((Episode)|(Folge)) \\d+[:\\-\\s]*");
 
 	/**
-	 * Creates a new EpisodeImporter with the given TMDb API key.
+	 * Constructs a new episode importer with the given TMDb client.
 	 *
-	 * @param apiKey the TMDb API key
+	 * @param client the TMDb client to use for API requests
 	 */
-	public EpisodeImporter(String apiKey) {
-		super(apiKey);
+	public EpisodeImporter(TmdbClient client) {
+		super(client);
 	}
 
-	/**
-	 * Runs the import with the current configuration for the given episode and TMDB episode data.
-	 *
-	 * @param episode the episode to import data into
-	 * @param seriesId the TMDB ID of the series
-	 * @param seasonNumber the season number
-	 * @param episodeNumber the episode number
-	 * @throws MediaImportException if the import fails due to a TMDb API error
-	 */
-	public void importData(Episode episode, int seriesId, int seasonNumber, int episodeNumber) throws MediaImportException {
-		importData(episode, seriesId, seasonNumber, episodeNumber, fetchAgeRatingsFromSeries(seriesId));
-	}
+	@Override
+	protected void initializeStrategy() {
+		strategies.put(ImportableAttribute.TITLE, createStringStrategy("name", Episode::getTitle, Episode::setTitle, title -> TITLE_PREFIX_PATTERN.matcher(title).replaceFirst("")));
+		strategies.put(ImportableAttribute.DESCRIPTION, createStringStrategy("overview", Episode::getDescription, Episode::setDescription));
+		strategies.put(ImportableAttribute.RUNTIME, createRuntimeStrategy("runtime", Episode::hasRuntime, Episode::setRuntime));
 
-	/**
-	 * Runs the import with the current configuration for the given episode and TMDB episode data.
-	 *
-	 * @param episode the episode to import data into
-	 * @param tmdbEpisode the TMDB episode data
-	 * @param ageRatings the age ratings of the series
-	 */
-	protected void importData(Episode episode, TvSeasonEpisode tmdbEpisode, Set<AgeRating> ageRatings) {
-		included.forEach(attribute -> {
-			switch (attribute) {
-				case TITLE -> {
-					String tmdbTitle = tmdbEpisode.getName();
-					if (tmdbTitle == null) {
-						break;
-					}
-					tmdbTitle = TITLE_PREFIX_PATTERN.matcher(tmdbTitle).replaceFirst("");
-					String title = episode.getTitle();
+		strategies.put(ImportableAttribute.AGE_RATING, (episode, json, context, override) -> {
+			if (context == null || context.seriesAgeRatings() == null) {
+				return;
+			}
+			final Set<AgeRating> ageRatings = context.seriesAgeRatings();
 
-					if (!tmdbTitle.isBlank() && (overridden.contains(attribute) || title == null || title.isBlank())) {
-						episode.setTitle(tmdbTitle);
-					}
+			if (ageRatings.isEmpty()) {
+				return;
+			}
+
+			for (RatingSystem ratingSystem : RatingSystem.values()) {
+				if (!override && episode.hasAgeRating(ratingSystem)) {
+					continue;
 				}
-				case DESCRIPTION -> {
-					String tmdbDescription = tmdbEpisode.getOverview();
-					String description = episode.getDescription();
-					if (tmdbDescription != null && (overridden.contains(attribute) || description == null || description.isBlank())) {
-						episode.setDescription(tmdbEpisode.getOverview());
-					}
+				final AgeRating rating = AgeRating.max(getAgeRatingsBySystem(ageRatings, ratingSystem));
+				if (rating == null) {
+					continue;
 				}
-				case RUNTIME -> {
-					Integer tmdbRuntime = tmdbEpisode.getRuntime();
-					int runtime = episode.getRuntime();
-					if (tmdbRuntime != null && (overridden.contains(attribute) || !episode.hasRuntime())) {
-						episode.setRuntime(tmdbEpisode.getRuntime());
-					}
-				}
-				case AGE_RATING -> {
-					for (RatingSystem ratingSystem : RatingSystem.values()) {
-						if (!overridden.contains(attribute) && episode.hasAgeRating(ratingSystem)) {
-							continue;
-						}
-						AgeRating rating = AgeRating.max(getAgeRatingsBySystem(ageRatings, ratingSystem));
-						if (rating == null) {
-							continue;
-						}
-						episode.setAgeRating(rating);
-					}
-				}
+				episode.setAgeRating(rating);
 			}
 		});
 	}
 
-	private void importData(Episode episode, int seriesId, int seasonNumber, int episodeNumber, Set<AgeRating> ageRatings) throws MediaImportException {
-		final TmdbTvEpisodes tmdbEpisodes = tmdbApi.getTvEpisodes();
+	protected void fill(Episode episode, JsonObject json, ImportContext context) {
+		applyAttributes(episode, json, context);
+	}
 
-		try {
-			TvEpisodeDb tmdbEpisode = tmdbEpisodes.getDetails(seriesId, seasonNumber, episodeNumber, language.getCode());
+	/**
+	 * Fills the given episode with data from TMDb for the given series ID, season number and episode number.
+	 *
+	 * @param episode the episode to fill
+	 * @param seriesId the TMDb ID of the parent series
+	 * @param seasonNumber the season number
+	 * @param episodeNumber the episode number
+	 * @throws MediaImportException if an error occurs during the import process
+	 */
+	public void fill(Episode episode, int seriesId, int seasonNumber, int episodeNumber) throws MediaImportException {
+		final JsonObject json = client.get("tv/" + seriesId + "/season/" + seasonNumber + "/episode/" + episodeNumber, language, null);
+		final Set<AgeRating> ageRatings = fetchSeriesAgeRatings(seriesId);
+		final ImportContext context = new ImportContext(seriesId, ageRatings);
+		applyAttributes(episode, json, context);
+	}
 
-			included.forEach(attribute -> {
-				switch (attribute) {
-					case TITLE -> {
-						String tmdbTitle = tmdbEpisode.getName();
-						if (tmdbTitle == null) {
-							break;
-						}
-						tmdbTitle = TITLE_PREFIX_PATTERN.matcher(tmdbTitle).replaceFirst("");
-						String title = episode.getTitle();
-
-						if (!tmdbTitle.isBlank() && (overridden.contains(attribute) || title == null || title.isBlank())) {
-							episode.setTitle(tmdbTitle);
-						}
-					}
-					case DESCRIPTION -> {
-						String tmdbDescription = tmdbEpisode.getOverview();
-						String description = episode.getDescription();
-
-						if (tmdbDescription != null && (overridden.contains(attribute) || description == null || description.isBlank())) {
-							episode.setDescription(tmdbDescription);
-						}
-					}
-					case RUNTIME -> {
-						Integer tmdbRuntime = tmdbEpisode.getRuntime();
-						int runtime = episode.getRuntime();
-
-						if (tmdbRuntime != null && (overridden.contains(attribute) || !episode.hasRuntime())) {
-							episode.setRuntime(tmdbRuntime);
-						}
-					}
-					case AGE_RATING -> {
-						for (RatingSystem ratingSystem : RatingSystem.values()) {
-							if (!overridden.contains(attribute) && episode.getAgeRating(ratingSystem) != null) {
-								continue;
-							}
-							AgeRating rating = AgeRating.max(getAgeRatingsBySystem(ageRatings, ratingSystem));
-							if (rating == null) {
-								continue;
-							}
-							episode.setAgeRating(rating);
-						}
-					}
-				}
-			});
-
-		} catch (TmdbException e) {
-			throw new MediaImportException("Error while trying to import episode data from TMDb", e);
-		}
-
+	/**
+	 * Creates a new episode and fills it with data from TMDb for the given series ID, season number and episode number.
+	 *
+	 * @param seriesTmdbId the TMDb ID of the parent series
+	 * @param seasonNumber the season number
+	 * @param episodeNumber the episode number
+	 * @return the newly created episode
+	 * @throws MediaImportException if an error occurs during the import process
+	 */
+	public Episode create(int seriesTmdbId, int seasonNumber, int episodeNumber) throws MediaImportException {
+		final Episode episode = new Episode(episodeNumber);
+		fill(episode, seriesTmdbId, seasonNumber, episodeNumber);
+		return episode;
 	}
 
 }

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/ImportContext.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/ImportContext.java
@@ -5,7 +5,7 @@ import de.unistuttgart.einf.moviemanager.model.age.AgeRating;
 import java.util.Set;
 
 /**
- * The import context used to pass information between importes in order to reduce
+ * The import context used to pass information between imports in order to reduce
  * the number of API requests.
  *
  * @param seriesId the TMDb ID of the series being imported, used by season and episode importers

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/ImportContext.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/ImportContext.java
@@ -1,0 +1,16 @@
+package de.unistuttgart.einf.moviemanager.dbimport;
+
+import de.unistuttgart.einf.moviemanager.model.age.AgeRating;
+
+import java.util.Set;
+
+/**
+ * The import context used to pass information between importes in order to reduce
+ * the number of API requests.
+ *
+ * @param seriesId the TMDb ID of the series being imported, used by season and episode importers
+ * @param seriesAgeRatings the age ratings of the series being imported, used by season and episode importers
+ */
+public record ImportContext(int seriesId, Set<AgeRating> seriesAgeRatings) {
+
+}

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/ImportStrategy.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/ImportStrategy.java
@@ -1,0 +1,16 @@
+package de.unistuttgart.einf.moviemanager.dbimport;
+
+import com.google.gson.JsonObject;
+import de.unistuttgart.einf.moviemanager.model.Media;
+
+/**
+ * A strategy to import media attributes from TMDb.
+ *
+ * @param <T> the type of media to import attributes for
+ */
+@FunctionalInterface
+public interface ImportStrategy<T extends Media> {
+
+	void apply(T media, JsonObject json, ImportContext context, boolean override);
+
+}

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/MediaImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/MediaImporter.java
@@ -3,42 +3,36 @@ package de.unistuttgart.einf.moviemanager.dbimport;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import de.unistuttgart.einf.moviemanager.model.Genre;
+import de.unistuttgart.einf.moviemanager.model.Media;
 import de.unistuttgart.einf.moviemanager.model.age.*;
-import info.movito.themoviedbapi.TmdbApi;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Abstract class for importing media data from TMDb.
  */
-public abstract class MediaImporter {
+public abstract class MediaImporter<T extends Media> {
 
-	protected final String apiKey;
-	protected final TmdbApi tmdbApi;
+	protected final TmdbClient client;
 	protected Language language;
 
 	protected final EnumSet<ImportableAttribute> included;
 	protected final EnumSet<ImportableAttribute> overridden;
+	protected final Map<ImportableAttribute, ImportStrategy<? super T>> strategies;
 
-	/**
-	 * Creates a new MediaImporter with the given TMDb API key.
-	 *
-	 * @param apiKey the TMDb API key
-	 */
-	public MediaImporter(String apiKey) {
-		this.apiKey = apiKey;
-		tmdbApi = new TmdbApi(apiKey);
+	public MediaImporter(TmdbClient client) {
+		this.client = client;
 		this.language = Language.ENGLISH;
-		included = EnumSet.noneOf(ImportableAttribute.class);
-		overridden = EnumSet.noneOf(ImportableAttribute.class);
+
+		this.included = EnumSet.noneOf(ImportableAttribute.class);
+		this.overridden = EnumSet.noneOf(ImportableAttribute.class);
+		this.strategies = new EnumMap<>(ImportableAttribute.class);
+
+		initializeStrategy();
 	}
 
 	/**
@@ -111,6 +105,66 @@ public abstract class MediaImporter {
 		return Collections.unmodifiableSet(overridden);
 	}
 
+	protected void applyAttributes(T media, JsonObject json, ImportContext context) {
+		for (ImportableAttribute attribute : included) {
+			final ImportStrategy<? super T> strategy = strategies.get(attribute);
+			if (strategy == null) {
+				continue;
+			}
+			strategy.apply(media, json, context, overridden.contains(attribute));
+		}
+	}
+
+	protected String getStringOrNull(JsonObject json, String key) {
+		if (!json.has(key) || json.get(key).isJsonNull()) {
+			return null;
+		}
+		return json.get(key).getAsString();
+	}
+
+	protected Integer getIntOrNull(JsonObject json, String key) {
+		if (!json.has(key) || json.get(key).isJsonNull()) {
+			return null;
+		}
+		return json.get(key).getAsInt();
+	}
+
+	protected Set<AgeRating> parseSeriesAgeRatings(JsonObject json) {
+		final Set<AgeRating> ageRatings = new HashSet<>();
+
+		if (!json.has("results")) {
+			return ageRatings;
+		}
+
+		final JsonArray results = json.getAsJsonArray("results");
+		for (JsonElement countryElement : results) {
+			final JsonObject countryObject = countryElement.getAsJsonObject();
+			final String iso31661 = countryObject.get("iso_3166_1").getAsString();
+			final String ratingString = countryObject.get("rating").getAsString();
+
+			if (!ratingString.isBlank()) {
+				final AgeRating ageRating = mapAgeRating(iso31661, ratingString);
+				if (ageRating != null) {
+					ageRatings.add(ageRating);
+				}
+			}
+		}
+
+		return ageRatings;
+	}
+
+	/**
+	 * Fetches age ratings for the given series ID from TMDb.
+	 *
+	 * @param seriesId the TMDb series ID
+	 * @return a set of age ratings
+	 */
+	protected Set<AgeRating> fetchSeriesAgeRatings(int seriesId) throws MediaImportException {
+		final Set<AgeRating> ageRatings = new HashSet<>();
+		final JsonObject jsonObject = client.get("tv/" + seriesId + "/content_ratings", language, null);
+		return parseSeriesAgeRatings(jsonObject);
+	}
+
 	/**
 	 * Maps the given country and age rating string to an AgeRating object.
 	 *
@@ -160,56 +214,8 @@ public abstract class MediaImporter {
 	}
 
 	/**
-	 * Fetches age ratings for the given series ID from TMDb.
-	 *
-	 * @param seriesId the TMDb series ID
-	 * @return a set of age ratings
-	 */
-	protected Set<AgeRating> fetchAgeRatingsFromSeries(int seriesId) throws MediaImportException {
-		Set<AgeRating> ageRatings = new HashSet<>();
-
-		try (HttpClient client = HttpClient.newHttpClient()) {
-			HttpRequest request = HttpRequest.newBuilder()
-					.GET()
-					.uri(new URI("https://api.themoviedb.org/3/tv/" + seriesId + "/content_ratings"))
-					.setHeader("accept", "application/json")
-					.setHeader("Authorization", "Bearer " + apiKey)
-					.build();
-			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-
-			JsonObject jsonObject = JsonParser.parseString(response.body()).getAsJsonObject();
-			JsonArray results = jsonObject.getAsJsonArray("results");
-
-			for (JsonElement country : results) {
-				JsonObject object = country.getAsJsonObject();
-
-				String iso31661 = object.get("iso_3166_1").getAsString();
-				String rating = object.get("rating").getAsString();
-
-				if (rating.isBlank()) {
-					continue;
-				}
-
-				AgeRating ageRating = mapAgeRating(iso31661, rating);
-				if (ageRating != null) {
-					ageRatings.add(ageRating);
-				}
-			}
-
-		} catch (IOException | URISyntaxException e) {
-			throw new MediaImportException("Error while trying to fetch the series' age ratings" + "e");
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			throw new MediaImportException("Error while trying to fetch the series' age ratings" + "e");
-		}
-
-		return ageRatings;
-	}
-
-	/**
 	 * Returns all genres from the given set of TMDb gerne ids.
-	 * The mappings were found here: https://www.themoviedb.org/talk/5daf6eb0ae36680011d7e6ee
+	 * The mappings were found <a href="https://www.themoviedb.org/talk/5daf6eb0ae36680011d7e6ee">here</a>.
 	 *
 	 * @param ids the set of TMDb genre ids
 	 * @return the set of mapped genres
@@ -263,6 +269,57 @@ public abstract class MediaImporter {
 			}
 		}
 		return genres;
+	}
+
+	protected abstract void initializeStrategy();
+
+	protected ImportStrategy<T> createStringStrategy(String key, Function<? super T, String> getter, BiConsumer<? super T, String> setter) {
+		return createStringStrategy(key, getter, setter, null);
+	}
+
+	protected ImportStrategy<T> createStringStrategy(String key, Function<? super T, String> getter, BiConsumer<? super T, String> setter, Function<String, String> mapper) {
+		return (media, json, context, override) -> {
+			String tmdbValue = getStringOrNull(json, key);
+			if (tmdbValue == null) {
+				return;
+			}
+
+			if (mapper != null) {
+				tmdbValue = mapper.apply(tmdbValue);
+			}
+
+			final String currentValue = getter.apply(media);
+			if (tmdbValue.isBlank() || (!override && currentValue != null && !currentValue.isBlank())) {
+				return;
+			}
+			setter.accept(media, tmdbValue);
+		};
+	}
+
+	protected ImportStrategy<T> createRuntimeStrategy(String key, Predicate<? super T> hasRuntime, BiConsumer<? super T, Integer> setter) {
+		return (media, json, context, override) -> {
+			final Integer tmdbRuntime = getIntOrNull(json, key);
+			if (tmdbRuntime == null || (!override && hasRuntime.test(media))) {
+				return;
+			}
+			setter.accept(media, tmdbRuntime);
+		};
+	}
+
+	protected ImportStrategy<T> createGenreStrategy(String key, BiConsumer<? super T, Genre> addGenre) {
+		return (media, json, context, override) -> {
+			if (!json.has(key)) {
+				return;
+			}
+			final Set<Integer> genreIds = new HashSet<>();
+			for (JsonElement element : json.getAsJsonArray(key)) {
+				genreIds.add(element.getAsJsonObject().get("id").getAsInt());
+			}
+			final Set<Genre> genres = mapGenres(genreIds);
+			for (Genre genre : genres) {
+				addGenre.accept(media, genre);
+			}
+		};
 	}
 
 }

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/MovieImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/MovieImporter.java
@@ -3,7 +3,6 @@ package de.unistuttgart.einf.moviemanager.dbimport;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import de.unistuttgart.einf.moviemanager.model.Genre;
 import de.unistuttgart.einf.moviemanager.model.Movie;
 import de.unistuttgart.einf.moviemanager.model.age.AgeRating;
 import de.unistuttgart.einf.moviemanager.model.age.RatingSystem;

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/MovieImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/MovieImporter.java
@@ -1,109 +1,105 @@
 package de.unistuttgart.einf.moviemanager.dbimport;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import de.unistuttgart.einf.moviemanager.model.Genre;
 import de.unistuttgart.einf.moviemanager.model.Movie;
 import de.unistuttgart.einf.moviemanager.model.age.AgeRating;
 import de.unistuttgart.einf.moviemanager.model.age.RatingSystem;
-import info.movito.themoviedbapi.TmdbMovies;
-import info.movito.themoviedbapi.model.core.IdElement;
-import info.movito.themoviedbapi.model.movies.MovieDb;
-import info.movito.themoviedbapi.model.movies.ReleaseType;
-import info.movito.themoviedbapi.tools.TmdbException;
 
-import java.util.Objects;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-public class MovieImporter extends MediaImporter{
+/**
+ * Used to import movie data from TMDb.
+ */
+public class MovieImporter extends MediaImporter<Movie> {
 
 	/**
-	 * Creates a new MovieImporter with the given TMDb API key.
+	 * Constructs a new movie importer with the given TMDb client.
 	 *
-	 * @param apiKey the TMDb API key
+	 * @param client the TMDb client to use for API requests
 	 */
-	public MovieImporter(String apiKey) {
-		super(apiKey);
+	public MovieImporter(TmdbClient client) {
+		super(client);
 	}
 
-	/**
-	 * Runs the import with the current configuration for the given movie and TMDB ID.
-	 *
-	 * @param movie the to import data into
-	 * @param tmdbId the TMDB ID of the movie
-	 * @throws MediaImportException if the import fails due to a TMDb API error
-	 */
-	public void importData(Movie movie, int tmdbId) throws MediaImportException {
-		final TmdbMovies tmdbMovies = tmdbApi.getMovies();
+	@Override
+	protected void initializeStrategy() {
+		strategies.put(ImportableAttribute.TITLE, createStringStrategy("title", Movie::getTitle, Movie::setTitle));
+		strategies.put(ImportableAttribute.DESCRIPTION, createStringStrategy("overview", Movie::getDescription, Movie::setDescription));
+		strategies.put(ImportableAttribute.RUNTIME, createRuntimeStrategy("runtime", Movie::hasRuntime, Movie::setRuntime));
+		strategies.put(ImportableAttribute.GENRE, createGenreStrategy("genres", Movie::addGenre));
 
-		try {
-			MovieDb tmdbMovie = tmdbMovies.getDetails(tmdbId, language.getCode());
+		strategies.put(ImportableAttribute.AGE_RATING, (movie, json, context, override) -> {
+			if (!json.has("release_dates")) {
+				return;
+			}
+			final Set<AgeRating> ageRatings = new HashSet<>();
+			final JsonArray countries = json.getAsJsonObject("release_dates").getAsJsonArray("results");
 
-			for (ImportableAttribute attribute : included) {
-				switch (attribute) {
-					case TITLE -> {
-						String tmdbTitle = tmdbMovie.getTitle();
-						String title = movie.getTitle();
+			for (JsonElement countryElement : countries) {
+				final JsonObject countryObject = countryElement.getAsJsonObject();
+				final String iso31661 = countryObject.get("iso_3166_1").getAsString();
+				final JsonArray releaseDates = countryObject.getAsJsonArray("release_dates");
 
-						if (tmdbTitle != null && (overridden.contains(attribute) || title == null || title.isBlank())) {
-							movie.setTitle(tmdbTitle);
-						}
+				for (JsonElement dateElement : releaseDates) {
+					final JsonObject dateObject = dateElement.getAsJsonObject();
+					final int releaseType = dateObject.get("type").getAsInt();
+					if (releaseType != 3) {
+						continue;
 					}
-					case DESCRIPTION -> {
-						String tmdbDescription = tmdbMovie.getOverview();
-						String description = movie.getDescription();
 
-						if (tmdbDescription != null && (overridden.contains(attribute) || description == null || description.isBlank())) {
-							movie.setDescription(tmdbDescription);
-						}
+					final String certification = dateObject.get("certification").getAsString();
+					final AgeRating rating = mapAgeRating(iso31661, certification);
+					if (rating == null) {
+						continue;
 					}
-					case RUNTIME -> {
-						Integer tmdbRuntime = tmdbMovie.getRuntime();
-
-						if (tmdbRuntime != null && (overridden.contains(attribute) || !movie.hasRuntime())) {
-							movie.setRuntime(tmdbRuntime);
-						}
-					}
-					case AGE_RATING -> {
-						Set<AgeRating> ageRatings = tmdbMovies.getReleaseDates(tmdbId).getResults().stream()
-								.flatMap(country -> country.getReleaseDates().stream()
-										.filter(releaseDate -> releaseDate.getType() == ReleaseType.THEATRICAL)
-										.map(releaseDate -> mapAgeRating(country.getIso31661(), releaseDate.getCertification())))
-								.filter(Objects::nonNull)
-								.collect(Collectors.toSet());
-
-						if (ageRatings.isEmpty()) {
-							continue;
-						}
-
-						for (RatingSystem ratingSystem : RatingSystem.values()) {
-							if (!overridden.contains(attribute) && movie.hasAgeRating(ratingSystem)) {
-								continue;
-							}
-							AgeRating rating = AgeRating.max(getAgeRatingsBySystem(ageRatings, ratingSystem));
-							if (rating == null) {
-								continue;
-							}
-							movie.setAgeRating(rating);
-						}
-					}
-					case GENRE -> {
-						Set<Genre> genres = mapGenres(tmdbMovie.getGenres().stream()
-								.map(IdElement::getId)
-								.collect(Collectors.toSet()));
-
-						for (Genre genre : genres) {
-							if (!overridden.contains(attribute) && movie.hasGenre(genre)) {
-								continue;
-							}
-							movie.addGenre(genre);
-						}
-					}
+					ageRatings.add(rating);
 				}
 			}
 
-		} catch (TmdbException e) {
-			throw new MediaImportException("Error while trying to import movie data from TMDb", e);
-		}
+			if (ageRatings.isEmpty()) {
+				return;
+			}
+
+			for (RatingSystem ratingSystem : RatingSystem.values()) {
+				if (!override && movie.hasAgeRating(ratingSystem)) {
+					continue;
+				}
+				final AgeRating rating = AgeRating.max(getAgeRatingsBySystem(ageRatings, ratingSystem));
+				if (rating == null) {
+					continue;
+				}
+				movie.setAgeRating(rating);
+			}
+		});
+	}
+
+	/**
+	 * Fills the given movie with data from TMDb for the given TMDb ID.
+	 *
+	 * @param movie the movie to fill
+	 * @param tmdbId the TMDb ID of the movie to import
+	 * @throws MediaImportException if an error occurs during the import process
+	 */
+	public void fill(Movie movie, int tmdbId) throws MediaImportException {
+		final JsonObject json = client.get("movie/" + tmdbId, language, "release_dates");
+		applyAttributes(movie, json, null);
+	}
+
+	/**
+	 * Creates a new movie and fills it with data from TMDb for the given TMDb ID.
+	 *
+	 * @param tmdbId the TMDb ID of the movie to import
+	 * @return the newly created movie
+	 * @throws MediaImportException if an error occurs during the import process
+	 */
+	public Movie create(int tmdbId) throws MediaImportException {
+		final Movie movie = new Movie();
+		fill(movie, tmdbId);
+		return movie;
 	}
 
 }

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/SeasonImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/SeasonImporter.java
@@ -1,43 +1,31 @@
 package de.unistuttgart.einf.moviemanager.dbimport;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import de.unistuttgart.einf.moviemanager.model.Episode;
+import de.unistuttgart.einf.moviemanager.model.Movie;
 import de.unistuttgart.einf.moviemanager.model.Season;
 import de.unistuttgart.einf.moviemanager.model.age.AgeRating;
-import info.movito.themoviedbapi.TmdbTvSeasons;
-import info.movito.themoviedbapi.TmdbTvSeries;
-import info.movito.themoviedbapi.model.tv.season.TvSeasonDb;
-import info.movito.themoviedbapi.model.tv.season.TvSeasonEpisode;
-import info.movito.themoviedbapi.model.tv.series.TvSeriesDb;
-import info.movito.themoviedbapi.tools.TmdbException;
 
-import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-public class SeasonImporter extends MediaImporter {
+/**
+ * Used to import season data from TMDb.
+ */
+public class SeasonImporter extends MediaImporter<Season> {
 
 	private EpisodeImporter episodeImporter;
 	private static final Pattern TITLE_PREFIX_PATTERN = Pattern.compile("((Season)|(Staffel)) \\d+[:\\-\\s]*");
 
 	/**
-	 * Creates a new SeasonImporter with the given TMDb API key.
+	 * Constructs a new season importer with the given TMDb client.
 	 *
-	 * @param apiKey the TMDb API key
+	 * @param client the TMDb client to use for API requests.
 	 */
-	public SeasonImporter(String apiKey) {
-		super(apiKey);
-	}
-
-	/**
-	 * Creates a new SeasonImporter with the given TMDb API key
-	 * and also sets the configuration for episode imports.
-	 *
-	 * @param apiKey the TMDb API key
-	 * @param episodeImporter the configuration used for episode imports
-	 */
-	public SeasonImporter(String apiKey, EpisodeImporter episodeImporter) {
-		super(apiKey);
-		this.episodeImporter = episodeImporter;
+	public SeasonImporter(TmdbClient client) {
+		super(client);
 	}
 
 	/**
@@ -59,87 +47,79 @@ public class SeasonImporter extends MediaImporter {
 		this.episodeImporter = episodeImporter;
 	}
 
-	/**
-	 * Runs the import with the current configuration for the given season and TMDB series ID.
-	 *
-	 * @param season the season to import data into
-	 * @param seriesId the TMDB ID of the series
-	 * @param seasonNumber the season number
-	 * @throws MediaImportException if the import fails due to a TMDb API error
-	 */
-	public void importData(Season season, int seriesId, int seasonNumber) throws MediaImportException {
-		TmdbTvSeries tmdbTvSeries = tmdbApi.getTvSeries();
+	@Override
+	protected void initializeStrategy() {
+		strategies.put(ImportableAttribute.TITLE, createStringStrategy("name", Season::getTitle, Season::setTitle, title -> TITLE_PREFIX_PATTERN.matcher(title).replaceFirst("")));
+		strategies.put(ImportableAttribute.DESCRIPTION, createStringStrategy("overview", Season::getDescription, Season::setDescription));
+	}
 
-		try {
-			TvSeriesDb tmdbSeries =  tmdbTvSeries.getDetails(seriesId, language.getCode());
-			importData(season, seriesId, seasonNumber, fetchAgeRatingsFromSeries(seriesId));
-		} catch (TmdbException e) {
-			throw new MediaImportException("Error while trying to import season data from TMDb", e);
+	protected void fill(Season season, JsonObject json, ImportContext context) throws MediaImportException {
+		if (episodeImporter == null || context == null) {
+			applyAttributes(season, json, context);
+			return;
 		}
 
+		json = client.get("tv/" + context.seriesId() + "/season/" + season.getNumber(), language, "content_ratings");
+
+		final Set<AgeRating> seriesAgeRatings;
+		if (context.seriesAgeRatings() == null) {
+			seriesAgeRatings = fetchSeriesAgeRatings(context.seriesId());
+		} else {
+			seriesAgeRatings = context.seriesAgeRatings();
+		}
+
+		context = new ImportContext(context.seriesId(), seriesAgeRatings);
+
+		applyAttributes(season, json, context);
+		if (!json.has("episodes")) {
+			return;
+		}
+
+		final JsonArray episodesArray = json.getAsJsonArray("episodes");
+		for (JsonElement episodeElement : episodesArray) {
+			final JsonObject episodeObject = episodeElement.getAsJsonObject();
+			final int episodeNumber = episodeObject.get("episode_number").getAsInt();
+
+			if (episodeNumber < 1) {
+				continue;
+			}
+
+			Episode episode = season.getChild(episodeNumber);
+			if (episode == null) {
+				episode = new Episode(episodeNumber);
+				season.addChild(episode);
+			}
+			episodeImporter.fill(episode, episodeObject, context);
+		}
 	}
 
 	/**
-	 * Runs the import with the current configuration for the given season, TMDB series ID and age ratings.
+	 * Fills the given season with data from TMDb for the given series ID and season number.
 	 *
-	 * @param season the season to import data into
-	 * @param seriesId the TMDB ID of the series
+	 * @param season the season to fill
+	 * @param seriesTmdbId the TMDb ID of the parent series
 	 * @param seasonNumber the season number
-	 * @param ageRatings the age ratings of the series
-	 * @throws MediaImportException if the import fails due to a TMDb API error
+	 * @throws MediaImportException if an error occurs during the import process
 	 */
-	protected void importData(Season season, int seriesId, int seasonNumber, Set<AgeRating> ageRatings) throws MediaImportException {
-		final TmdbTvSeasons tmdbSeasons = tmdbApi.getTvSeasons();
+	public void fill(Season season, int seriesTmdbId, int seasonNumber) throws MediaImportException {
+		final JsonObject json = client.get("tv/" + seriesTmdbId + "/season/" + seasonNumber, language, "content_ratings");
+		final Set<AgeRating> ageRatings = fetchSeriesAgeRatings(seriesTmdbId);
+		final ImportContext context = new ImportContext(seriesTmdbId, ageRatings);
+		fill(season, json, context);
+	}
 
-		try {
-			TvSeasonDb tmdbSeason = tmdbSeasons.getDetails(seriesId, seasonNumber, language.getCode());
-
-			included.forEach(attribute -> {
-				switch (attribute) {
-					case TITLE -> {
-						String tmdbTitle = tmdbSeason.getName();
-						if (tmdbTitle == null) {
-							break;
-						}
-						tmdbTitle = TITLE_PREFIX_PATTERN.matcher(tmdbTitle).replaceFirst("");
-						String title = season.getTitle();
-
-						if (!tmdbTitle.isBlank() && (overridden.contains(attribute) || title == null || title.isBlank())) {
-							season.setTitle(tmdbTitle);
-						}
-					}
-					case DESCRIPTION -> {
-						String tmdbDescription = tmdbSeason.getOverview();
-						String description = season.getDescription();
-
-						if (tmdbDescription != null && (overridden.contains(attribute) || description == null || description.isBlank())) {
-							season.setDescription(tmdbDescription);
-						}
-					}
-				}
-			});
-
-			if (episodeImporter == null) {
-				return;
-			}
-
-			List<TvSeasonEpisode> tmdbEpisodes = tmdbSeason.getEpisodes();
-			for (TvSeasonEpisode tmdbEpisode : tmdbEpisodes) {
-				if (tmdbEpisode.getEpisodeNumber() < 1) {
-					continue;
-				}
-				int episodeNumber = tmdbEpisode.getEpisodeNumber();
-				Episode episode = season.getChild(episodeNumber);
-				if (episode == null) {
-					episode = new Episode(episodeNumber);
-					season.addChild(episode);
-				}
-				episodeImporter.importData(episode, tmdbEpisode, ageRatings);
-			}
-
-		} catch (TmdbException e) {
-			throw new MediaImportException("Error while trying to import season data from TMDb", e);
-		}
+	/**
+	 * Creates a new season and fills it with data from TMDb for the given series ID and season number.
+	 *
+	 * @param seriesTmdbId the TMDb ID of the parent series
+	 * @param seasonNumber the season number
+	 * @return the newly created season
+	 * @throws MediaImportException if an error occurs during the import process
+	 */
+	public Season create(int seriesTmdbId, int seasonNumber) throws MediaImportException {
+		final Season season = new Season(seasonNumber);
+		fill(season, seriesTmdbId, seasonNumber);
+		return season;
 	}
 
 }

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/SeasonImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/SeasonImporter.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import de.unistuttgart.einf.moviemanager.model.Episode;
-import de.unistuttgart.einf.moviemanager.model.Movie;
 import de.unistuttgart.einf.moviemanager.model.Season;
 import de.unistuttgart.einf.moviemanager.model.age.AgeRating;
 

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/SeriesImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/SeriesImporter.java
@@ -1,42 +1,25 @@
 package de.unistuttgart.einf.moviemanager.dbimport;
 
-import de.unistuttgart.einf.moviemanager.model.Genre;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import de.unistuttgart.einf.moviemanager.model.Season;
 import de.unistuttgart.einf.moviemanager.model.Series;
-import de.unistuttgart.einf.moviemanager.model.age.AgeRating;
-import info.movito.themoviedbapi.TmdbTvSeries;
-import info.movito.themoviedbapi.model.core.IdElement;
-import info.movito.themoviedbapi.model.tv.core.TvSeason;
-import info.movito.themoviedbapi.model.tv.series.TvSeriesDb;
-import info.movito.themoviedbapi.tools.TmdbException;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-public class SeriesImporter extends MediaImporter {
+/**
+ * Used to import series data from TMDb.
+ */
+public class SeriesImporter extends MediaImporter<Series> {
 
 	private SeasonImporter seasonImporter;
 
 	/**
-	 * Creates a new SeriesImporter with the given TMDb API key.
+	 * Constructs a new series importer with the given TMDb client.
 	 *
-	 * @param apiKey the TMDb API key
+	 * @param client the TMDb client to use for API requests
 	 */
-	public SeriesImporter(String apiKey) {
-		super(apiKey);
-	}
-
-	/**
-	 * Creates a new SeriesImporter with the given TMDb API key
-	 * and also sets the configuration for season imports.
-	 *
-	 * @param apiKey the TMDb API key
-	 * @param seasonImporter the configuration used for season imports
-	 */
-	public SeriesImporter(String apiKey, SeasonImporter seasonImporter) {
-		super(apiKey);
-		this.seasonImporter = seasonImporter;
+	public SeriesImporter(TmdbClient client) {
+		super(client);
 	}
 
 	/**
@@ -58,76 +41,59 @@ public class SeriesImporter extends MediaImporter {
 		this.seasonImporter = seasonImporter;
 	}
 
+	@Override
+	protected void initializeStrategy() {
+		strategies.put(ImportableAttribute.TITLE, createStringStrategy("name", Series::getTitle, Series::setTitle));
+		strategies.put(ImportableAttribute.DESCRIPTION, createStringStrategy("overview", Series::getDescription, Series::setDescription));
+		strategies.put(ImportableAttribute.GENRE, createGenreStrategy("genres", Series::addGenre));
+	}
+
 	/**
-	 * Runs the import with the current configuration for the given series and TMDB ID.
+	 * Fills the given series with data from TMDb for the given series ID.
 	 *
-	 * @param series the series to import data into
-	 * @param seriesId the TMDB ID of the series
-	 * @throws MediaImportException if the import fails due to a TMDb API error
+	 * @param series the series to fill
+	 * @param tmdbId the TMDb ID of the series to import
+	 * @throws MediaImportException if an error occurs during the import process
 	 */
-	public void importData(Series series, int seriesId) throws MediaImportException {
-		final TmdbTvSeries tmdbTvSeries = tmdbApi.getTvSeries();
+	public void fill(Series series, int tmdbId) throws MediaImportException {
+		final JsonObject json = client.get("tv/" + tmdbId, language, "content_ratings");
+		final JsonObject contentRatings = json.getAsJsonObject("content_ratings");
+		final ImportContext context = new ImportContext(tmdbId, parseSeriesAgeRatings(contentRatings));
+		applyAttributes(series, json, context);
 
-		try {
-			TvSeriesDb tmdbSeries = tmdbTvSeries.getDetails(seriesId, language.getCode());
-
-			included.forEach(attribute -> {
-				switch (attribute) {
-					case TITLE -> {
-						String tmdbTitle = tmdbSeries.getName();
-						String title = series.getTitle();
-						
-						if (tmdbTitle != null && (overridden.contains(attribute) || title == null || title.isBlank())) {
-							series.setTitle(tmdbTitle);
-						}
-					}
-					case DESCRIPTION -> {
-						String tmdbDescription = tmdbSeries.getOverview();
-						String description = series.getDescription();
-						
-						if (tmdbDescription != null && (overridden.contains(attribute) || description == null ||description.isBlank())) {
-							series.setDescription(tmdbDescription);
-						}
-					}
-					case GENRE -> {
-						Set<Genre> genres = mapGenres(tmdbSeries.getGenres().stream()
-								.map(IdElement::getId)
-								.collect(Collectors.toSet()));
-
-						for (Genre genre : genres) {
-							if (!overridden.contains(attribute) && series.hasGenre(genre)) {
-								continue;
-							}
-							series.addGenre(genre);
-						}
-					}
-
-				}
-			});
-
-			if (seasonImporter == null) {
-				return;
-			}
-
-			List<TvSeason> seasons = tmdbSeries.getSeasons();
-			Set<AgeRating> ageRatings = fetchAgeRatingsFromSeries(seriesId);
-			for (TvSeason tmdbSeason : seasons) {
-				if (tmdbSeason.getSeasonNumber() < 1) {
-					continue;
-				}
-				int seasonNumber = tmdbSeason.getSeasonNumber();
-				Season season = series.getChild(seasonNumber);
-				if (season == null) {
-					season = new Season(seasonNumber);
-					series.addChild(season);
-				}
-				seasonImporter.importData(season, seriesId, seasonNumber, ageRatings);
-			}
-
-		} catch (TmdbException e) {
-			throw new MediaImportException("Error while trying to import series data from TMDb", e);
+		if (seasonImporter == null || !json.has("seasons")) {
+			return;
 		}
 
+		final JsonArray seasonsArray = json.getAsJsonArray("seasons");
+		for (JsonElement seasonElement : seasonsArray) {
+			final JsonObject seasonObject = seasonElement.getAsJsonObject();
+			final int seasonNumber = seasonObject.get("season_number").getAsInt();
+
+			if (seasonNumber < 1) {
+				continue;
+			}
+
+			Season season = series.getChild(seasonNumber);
+			if (season == null) {
+				season = new Season(seasonNumber);
+				series.addChild(season);
+			}
+			seasonImporter.fill(season, seasonObject, context);
+		}
+	}
+
+	/**
+	 * Creates a new series and fills it with data from TMDb for the given TMDb ID.
+	 *
+	 * @param tmdbId the TMDb ID of the series to import
+	 * @return the newly create series
+	 * @throws MediaImportException if an error occurs during the import process
+	 */
+	public Series create(int tmdbId) throws MediaImportException {
+		final Series series = new Series();
+		fill(series, tmdbId);
+		return series;
 	}
 
 }

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbClient.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbClient.java
@@ -1,0 +1,85 @@
+package de.unistuttgart.einf.moviemanager.dbimport;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import okhttp3.*;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * The client to access the TMDb API.
+ */
+public class TmdbClient {
+
+	private static final String SCHEME = "https";
+	private static final String HOST = "api.themoviedb.org";
+	private static final String VERSION_SEGMENT = "3";
+
+	private final OkHttpClient client;
+	private final Supplier<String> apiKeySupplier;
+
+	/**
+	 * Constructs a new tmdb client with the given api key supplier.
+	 *
+	 * @param apiKeySupplier the api key supplier
+	 * @throws IllegalArgumentException if apiKeySupplier is null
+	 */
+	public TmdbClient(Supplier<String> apiKeySupplier) {
+		if (apiKeySupplier == null) {
+			throw new IllegalArgumentException("apiKeySupplier must be non-null");
+		}
+		this.apiKeySupplier = apiKeySupplier;
+		this.client = new OkHttpClient();
+	}
+
+	/**
+	 * Performs a GET request to the TMDb API with the given endpoint, language and appendToResponse parameters.
+	 *
+	 * @param endpoint the API endpoint to call, e.g. "movie/550" or "tv/1399"
+	 * @param language the language for the response (default: English)
+	 * @param appendToResponse a comma-separated list of additional data to include in the response, e.g. "images,videos" (optional)
+	 * @return the JSON response from the TMDb API as a JsonObject
+	 * @throws MediaImportException if the API key is missing or invalid, if the endpoint is null, if the HTTP request fails, or if a network error occurs
+	 */
+	public JsonObject get(String endpoint, Language language, String appendToResponse) throws MediaImportException {
+		if (endpoint == null) {
+			throw new IllegalArgumentException("Endpoint cannot be null");
+		}
+
+		final String apiKey = apiKeySupplier.get();
+		if (apiKey == null || apiKey.isBlank()) {
+			throw new MediaImportException("API key is missing or invalid");
+		}
+
+		language = language == null ? Language.ENGLISH : language;
+
+		final HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
+				.scheme(SCHEME)
+				.host(HOST)
+				.addPathSegment(VERSION_SEGMENT)
+				.addPathSegments(endpoint)
+				.addQueryParameter("language", language.getCode());
+
+		if (appendToResponse != null && !appendToResponse.isBlank()) {
+			urlBuilder.addQueryParameter("append_to_response", appendToResponse);
+		}
+
+		final Request request = new Request.Builder()
+				.get()
+				.url(urlBuilder.build())
+				.addHeader("accept", "application/json")
+				.addHeader("Authorization", "Bearer " + apiKey)
+				.build();
+
+		try (Response response = client.newCall(request).execute()) {
+			if (!response.isSuccessful()) {
+				throw new MediaImportException("HTTP request failed with status code: " + response.code());
+			}
+			return JsonParser.parseString(response.body().string()).getAsJsonObject();
+		} catch (IOException exception) {
+			throw new MediaImportException("Network error occurred during TMDb API call", exception);
+		}
+	}
+
+}


### PR DESCRIPTION
### Description

This PR replaces the wrapper with custom HTTP requests via a `TmdbClient`. The number of API calls is reduced to the minimum, by using TMDb's [append to response feature](https://developer.themoviedb.org/docs/append-to-response) and passing json and context down to child importers.