### PR TITLE
Add TMDb search functionality to import command

### DIFF
--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/Cli.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/Cli.java
@@ -9,6 +9,7 @@ import com.googlecode.lanterna.terminal.Terminal;
 import de.unistuttgart.einf.moviemanager.cli.api.*;
 import de.unistuttgart.einf.moviemanager.cli.api.layout.HorizontalBorderPane;
 import de.unistuttgart.einf.moviemanager.cli.api.layout.VerticalBorderPane;
+import de.unistuttgart.einf.moviemanager.cli.api.popover.Popover;
 import de.unistuttgart.einf.moviemanager.cli.api.widget.CommandLine;
 import de.unistuttgart.einf.moviemanager.cli.api.widget.ConfirmationDialog;
 import de.unistuttgart.einf.moviemanager.cli.api.widget.Text;
@@ -444,6 +445,32 @@ public class Cli {
 		});
 
 		dialog.show(scene);
+	}
+
+	/**
+	 * Shows the given popover.
+	 *
+	 * @param popover the popover to show
+	 */
+	public void showPopover(Popover popover) {
+		final Interactable currentFocus = scene.getFocusManager().getCurrentFocus();
+		if (currentPage.isChild(currentFocus)) {
+			currentPage.setFocusCache(currentFocus);
+		}
+
+		final Runnable existingOnClosed = popover.getOnClosed();
+
+		popover.setOnClosed(() -> {
+			if (existingOnClosed != null) {
+				existingOnClosed.run();
+			}
+
+			if (currentPage.isChild(currentPage.getFocusCache())) {
+				currentPage.getFocusCache().requestFocus();
+			}
+		});
+
+		scene.showPopover(popover);
 	}
 
 	/* *************************************************************** *

--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/HelpCommand.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/HelpCommand.java
@@ -31,17 +31,21 @@ public class HelpCommand {
 				""");
 
 		commandToHelpMessage.put("import", """
-				Imports media from The Movie Database (TMDb). You can either provide a direct URL or an ID.
+				Imports media from The Movie Database (TMDb). You can search, or provide a direct URL or an ID.
 				
-				1. Using a URL (easiest):
+				1. Searching
+				:import search [movie|series] <query>
+				Example: :import search movie Matrix
+				
+				2. Using a URL (easiest):
 				:import <tmdb-url> [<language>]
-				Example: :import https://www.themoviedb.org/movie/603-the-matrix
+				Example: :import "https://www.themoviedb.org/movie/603-the-matrix" 
 				
-				2. Using an ID:
+				3. Using an ID:
 				:import movie|series <tmdb-id> [<language>]
 				Example: :import movie 603
 				
-				3. Importing Seasons/Episodes:
+				4. Importing Seasons/Episodes:
 				:import season [<series>] <season-number> <series-tmdb-id>
 				:import episode [<series>] <season-number> <episode-number> <series-tmdb-id>
 				

--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/ImportCommand.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/ImportCommand.java
@@ -354,7 +354,7 @@ public class ImportCommand {
 						case SERIES -> "[S]";
 						default -> "[?]";
 					};
-					return prefix + " " + result.title() + " (ID: " + result.id() + ")";
+					return prefix + " " + result.title() + (result.releaseDate() == null ? "" : " (" + result.releaseDate().getYear() + ")") + " [id: " + result.id() + "]";
 				},
 				(selectedResult, language) -> {
 					switch (selectedResult.type()) {
@@ -371,7 +371,7 @@ public class ImportCommand {
 				context,
 				cli,
 				TmdbSearcher::searchMovies,
-				result -> result.title() + " (ID: " + result.id() + ")",
+				result -> result.title() + (result.releaseDate() == null ? "" : " (" + result.releaseDate().getYear() + ")") + " [id: " + result.id() + "]",
 				(selectedResult, language) -> performImportMovie(cli, selectedResult.id(), language),
 				"Failed to search for movies with query"
 		);
@@ -382,7 +382,7 @@ public class ImportCommand {
 				context,
 				cli,
 				TmdbSearcher::searchSeries,
-				result -> result.title() + " (ID: " + result.id() + ")",
+				result -> result.title() + (result.releaseDate() == null ? "" : " (" + result.releaseDate().getYear() + ")") + " [id: " + result.id() + "]",
 				(selectedResult, language) -> performImportSeries(cli, selectedResult.id(), language),
 				"Failed to search for series with query"
 		);

--- a/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/ImportCommand.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/cli/commands/ImportCommand.java
@@ -1,19 +1,25 @@
 package de.unistuttgart.einf.moviemanager.cli.commands;
 
 import de.unistuttgart.einf.moviemanager.cli.Cli;
+import de.unistuttgart.einf.moviemanager.cli.api.Insets;
+import de.unistuttgart.einf.moviemanager.cli.api.popover.CenteredPlacement;
+import de.unistuttgart.einf.moviemanager.cli.api.popover.Popover;
 import de.unistuttgart.einf.moviemanager.cli.api.util.TextUtils;
+import de.unistuttgart.einf.moviemanager.cli.api.widget.ListView;
 import de.unistuttgart.einf.moviemanager.command.Command;
 import de.unistuttgart.einf.moviemanager.command.CommandDispatcher;
+import de.unistuttgart.einf.moviemanager.command.CommandExecutionException;
 import de.unistuttgart.einf.moviemanager.command.ExecutionContext;
-import de.unistuttgart.einf.moviemanager.command.argument.EnumArgument;
-import de.unistuttgart.einf.moviemanager.command.argument.IntegerArgument;
-import de.unistuttgart.einf.moviemanager.command.argument.LiteralArgument;
-import de.unistuttgart.einf.moviemanager.command.argument.SeriesArgument;
+import de.unistuttgart.einf.moviemanager.command.argument.*;
 import de.unistuttgart.einf.moviemanager.dbimport.*;
 import de.unistuttgart.einf.moviemanager.model.Episode;
 import de.unistuttgart.einf.moviemanager.model.Movie;
 import de.unistuttgart.einf.moviemanager.model.Season;
 import de.unistuttgart.einf.moviemanager.model.Series;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * The command to import media from TMDb.
@@ -81,7 +87,26 @@ public class ImportCommand {
 										.then(IntegerArgument.create("series-tmdb-id").withMin(0)
 												.executes(context -> executeImportEpisode(context, cli))
 												.then(EnumArgument.create("language", Language.class)
-														.executes(context -> executeImportEpisode(context, cli))))))));
+														.executes(context -> executeImportEpisode(context, cli)))))))
+				// import [movie|series] search <query> [<language>]
+				.then(LiteralArgument.create("search")
+						// search <query> [<language>]
+						.then(StringArgument.create("query")
+								.executes(context -> executeSearch(context, cli))
+								.then(EnumArgument.create("language", Language.class)
+										.executes(context -> executeSearch(context, cli))))
+						// search movie <query> [<language>]
+						.then(LiteralArgument.create("movie")
+								.then(StringArgument.create("query")
+										.executes(context -> executeSearchMovies(context, cli))
+										.then(EnumArgument.create("language", Language.class)
+												.executes(context -> executeSearchMovies(context, cli)))))
+						// search series <query> [<language>]
+						.then(LiteralArgument.create("series")
+								.then(StringArgument.create("query")
+										.executes(context -> executeSearchSeries(context, cli))
+										.then(EnumArgument.create("language", Language.class)
+												.executes(context -> executeSearchSeries(context, cli)))))));
 	}
 
 	private static void executeImportUrl(ExecutionContext context, Cli cli) {
@@ -255,6 +280,112 @@ public class ImportCommand {
 		final EpisodeImporter episodeImporter = new EpisodeImporter(cli.getTmdbClient());
 		episodeImporter.include(ImportableAttribute.values());
 		return episodeImporter;
+	}
+
+	@FunctionalInterface
+	private interface SearchProvider {
+		List<TmdbSearcher.SearchResult> search(TmdbSearcher searcher, String query, Language language) throws MediaImportException;
+	}
+
+	private static void executeGenericSearch(ExecutionContext context, Cli cli, SearchProvider searchProvider,
+			Function<TmdbSearcher.SearchResult, String> displayFunction, BiConsumer<TmdbSearcher.SearchResult, Language> importAction, String errorMessage) {
+		final String query = context.getString("query");
+		final Language language = getLanguage(context, cli);
+
+		final TmdbSearcher searcher = new TmdbSearcher(cli.getTmdbClient());
+		final List<TmdbSearcher.SearchResult> results;
+		try {
+			results = searchProvider.search(searcher, query, language);
+		} catch (MediaImportException exception) {
+			throw Command.fail(errorMessage + " '" + query + "'. Do you have a stable internet connection? Is the TMDb API key set and valid?");
+		}
+
+		if (results.isEmpty()) {
+			cli.showInfoDialog("No results found for query: " + query);
+			return;
+		}
+
+		final ListView<TmdbSearcher.SearchResult> resultListView = new ListView<>(displayFunction);
+		resultListView.setItems(results);
+		resultListView.setPadding(new Insets(0, 1));
+
+		final int maximumAllowedHeight = 15;
+		final int calculatedHeight = Math.min(maximumAllowedHeight, results.size());
+		resultListView.setHeight(calculatedHeight);
+
+		final int maximumAllowedWidth = 80;
+		int calculatedWidth = 20;
+		for (TmdbSearcher.SearchResult result : results) {
+			final String displayString = displayFunction.apply(result);
+			if (displayString.length() > calculatedWidth) {
+				calculatedWidth = displayString.length();
+			}
+		}
+		calculatedWidth = Math.min(maximumAllowedWidth, calculatedWidth);
+		resultListView.setWidth(calculatedWidth + 2);
+
+		final CenteredPlacement placementStrategy = new CenteredPlacement();
+		final Popover searchPopover = new Popover(resultListView, placementStrategy);
+		searchPopover.setShowBorders(true);
+
+		resultListView.setOnItemSelected((selectedResult, index) -> {
+			if (resultListView.getScene() != null) {
+				resultListView.getScene().attemptClosePopover();
+			}
+			try {
+				importAction.accept(selectedResult, language);
+			} catch (CommandExecutionException exception) {
+				cli.showInfoDialog(exception.getMessage());
+			}
+		});
+
+		cli.showPopover(searchPopover);
+		resultListView.requestFocus();
+	}
+
+	private static void executeSearch(ExecutionContext context, Cli cli) {
+		executeGenericSearch(
+				context,
+				cli,
+				TmdbSearcher::searchMedia,
+				result -> {
+					final String prefix = switch (result.type()) {
+						case MOVIE -> "[M]";
+						case SERIES -> "[S]";
+						default -> "[?]";
+					};
+					return prefix + " " + result.title() + " (ID: " + result.id() + ")";
+				},
+				(selectedResult, language) -> {
+					switch (selectedResult.type()) {
+						case MOVIE -> performImportMovie(cli, selectedResult.id(), language);
+						case SERIES -> performImportSeries(cli, selectedResult.id(), language);
+					}
+				},
+				"Failed to search for media with query"
+		);
+	}
+
+	private static void executeSearchMovies(ExecutionContext context, Cli cli) {
+		executeGenericSearch(
+				context,
+				cli,
+				TmdbSearcher::searchMovies,
+				result -> result.title() + " (ID: " + result.id() + ")",
+				(selectedResult, language) -> performImportMovie(cli, selectedResult.id(), language),
+				"Failed to search for movies with query"
+		);
+	}
+
+	private static void executeSearchSeries(ExecutionContext context, Cli cli) {
+		executeGenericSearch(
+				context,
+				cli,
+				TmdbSearcher::searchSeries,
+				result -> result.title() + " (ID: " + result.id() + ")",
+				(selectedResult, language) -> performImportSeries(cli, selectedResult.id(), language),
+				"Failed to search for series with query"
+		);
 	}
 
 }

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/EpisodeImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/EpisodeImporter.java
@@ -67,7 +67,7 @@ public class EpisodeImporter extends MediaImporter<Episode> {
 	 * @throws MediaImportException if an error occurs during the import process
 	 */
 	public void fill(Episode episode, int seriesId, int seasonNumber, int episodeNumber) throws MediaImportException {
-		final JsonObject json = client.get("tv/" + seriesId + "/season/" + seasonNumber + "/episode/" + episodeNumber, language, null);
+		final JsonObject json = client.get("tv/" + seriesId + "/season/" + seasonNumber + "/episode/" + episodeNumber, language);
 		final Set<AgeRating> ageRatings = fetchSeriesAgeRatings(seriesId);
 		final ImportContext context = new ImportContext(seriesId, ageRatings);
 		applyAttributes(episode, json, context);

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/MediaImporter.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/MediaImporter.java
@@ -161,7 +161,7 @@ public abstract class MediaImporter<T extends Media> {
 	 */
 	protected Set<AgeRating> fetchSeriesAgeRatings(int seriesId) throws MediaImportException {
 		final Set<AgeRating> ageRatings = new HashSet<>();
-		final JsonObject jsonObject = client.get("tv/" + seriesId + "/content_ratings", language, null);
+		final JsonObject jsonObject = client.get("tv/" + seriesId + "/content_ratings", language);
 		return parseSeriesAgeRatings(jsonObject);
 	}
 

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbClient.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbClient.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonParser;
 import okhttp3.*;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -34,6 +36,18 @@ public class TmdbClient {
 	}
 
 	/**
+	 * Performs a GET request to the TMDb API with the given endpoint and language.
+	 *
+	 * @param endpoint the API endpoint to call, e.g. "movie/550" or "tv/1399"
+	 * @param language the language for the response (default: English)
+	 * @return the JSON response from the TMDb API as a JsonObject
+	 * @throws MediaImportException if the API key is missing or invalid, if the endpoint is null, if the HTTP request fails, or if a network error occurs
+	 */
+	public JsonObject get(String endpoint, Language language) throws MediaImportException {
+		return get(endpoint, language, (Map<String, String>) null);
+	}
+
+	/**
 	 * Performs a GET request to the TMDb API with the given endpoint, language and appendToResponse parameters.
 	 *
 	 * @param endpoint the API endpoint to call, e.g. "movie/550" or "tv/1399"
@@ -43,6 +57,25 @@ public class TmdbClient {
 	 * @throws MediaImportException if the API key is missing or invalid, if the endpoint is null, if the HTTP request fails, or if a network error occurs
 	 */
 	public JsonObject get(String endpoint, Language language, String appendToResponse) throws MediaImportException {
+		final Map<String, String> queryParameters = new HashMap<>();
+
+		if (appendToResponse != null && !appendToResponse.isBlank()) {
+			queryParameters.put("append_to_response", appendToResponse);
+		}
+
+		return get(endpoint, language, queryParameters);
+	}
+
+	/**
+	 * Performs a GET request to the TMDb API with the given endpoint, language and custom query parameters.
+	 *
+	 * @param endpoint the API endpoint to call, e.g. "search/movie"
+	 * @param language the language for the response (default: English)
+	 * @param queryParameters a map of additional query parameters to include in the request
+	 * @return the JSON response from the TMDb API as a JsonObject
+	 * @throws MediaImportException if the API key is missing or invalid, if the endpoint is null, if the HTTP request fails, or if a network error occurs
+	 */
+	public JsonObject get(String endpoint, Language language, Map<String, String> queryParameters) throws MediaImportException {
 		if (endpoint == null) {
 			throw new IllegalArgumentException("Endpoint cannot be null");
 		}
@@ -61,8 +94,8 @@ public class TmdbClient {
 				.addPathSegments(endpoint)
 				.addQueryParameter("language", language.getCode());
 
-		if (appendToResponse != null && !appendToResponse.isBlank()) {
-			urlBuilder.addQueryParameter("append_to_response", appendToResponse);
+		if (queryParameters != null) {
+			queryParameters.forEach(urlBuilder::addQueryParameter);
 		}
 
 		final Request request = new Request.Builder()

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -16,7 +17,7 @@ public class TmdbSearcher {
 		this.client = client;
 	}
 
-	public record SearchResult(int id, String title, MediaType type) {}
+	public record SearchResult(int id, String title, MediaType type, LocalDate releaseDate) {}
 
 	private List<SearchResult> executeSearchRequest(String endpoint, String query, Language language, java.util.function.Function<JsonObject, MediaType> mediaTypeExtractor) throws MediaImportException {
 		final JsonObject json = client.get(endpoint, language, Map.of("query", query));
@@ -46,7 +47,16 @@ public class TmdbSearcher {
 			final int identifier = searchResultObject.get("id").getAsInt();
 			final String title = searchResultObject.get("title").getAsString();
 
-			results.add(new SearchResult(identifier, title, mediaType));
+			final LocalDate releaseDate;
+			if (searchResultObject.has("release_date") && !searchResultObject.get("release_date").getAsString().isEmpty()) {
+				releaseDate = LocalDate.parse(searchResultObject.get("release_date").getAsString());
+			} else if (searchResultObject.has("first_air_date") && !searchResultObject.get("first_air_date").getAsString().isEmpty()) {
+				releaseDate = LocalDate.parse(searchResultObject.get("first_air_date").getAsString());
+			} else {
+				releaseDate = null;
+			}
+
+			results.add(new SearchResult(identifier, title, mediaType, releaseDate));
 		}
 
 		return results;

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * A helper class to search for media on TMDb.
@@ -35,7 +36,7 @@ public class TmdbSearcher {
 	 */
 	public record SearchResult(int id, String title, MediaType type, LocalDate releaseDate) {}
 
-	private List<SearchResult> executeSearchRequest(String endpoint, String query, Language language, java.util.function.Function<JsonObject, MediaType> mediaTypeExtractor) throws MediaImportException {
+	private List<SearchResult> executeSearchRequest(String endpoint, String query, Language language, Function<JsonObject, MediaType> mediaTypeExtractor) throws MediaImportException {
 		final JsonObject json = client.get(endpoint, language, Map.of("query", query));
 
 		if (!json.has("results") || !json.get("results").isJsonArray()) {

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
@@ -1,0 +1,108 @@
+package de.unistuttgart.einf.moviemanager.dbimport;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class TmdbSearcher {
+
+	private final TmdbClient client;
+
+	public TmdbSearcher(TmdbClient client) {
+		this.client = client;
+	}
+
+	public record SearchResult(int id, String title, MediaType type) {}
+
+	public List<SearchResult> searchMovies(String query, Language language) throws MediaImportException {
+		final JsonObject json = client.get("search/movie", language, Map.of("query", query));
+
+		if (!json.has("results") || !json.get("results").isJsonArray()) {
+			throw new MediaImportException("Invalid response from TMDb API: missing 'results' array");
+		}
+
+		final List<SearchResult> results = new ArrayList<>();
+
+		final JsonArray resultsArray = json.getAsJsonArray("results");
+		for (JsonElement movieElement : resultsArray) {
+			if (!movieElement.isJsonObject()) {
+				continue;
+			}
+			final JsonObject movieObject = movieElement.getAsJsonObject();
+			if (!movieObject.has("id") || !movieObject.has("title")) {
+				continue;
+			}
+			final int id = movieObject.get("id").getAsInt();
+			final String title = movieObject.get("title").getAsString();
+			results.add(new SearchResult(id, title, MediaType.MOVIE));
+		}
+
+		return results;
+	}
+
+	public List<SearchResult> searchSeries(String query, Language language) throws MediaImportException {
+		final JsonObject json = client.get("search/series", language, Map.of("query", query));
+
+		if (!json.has("results") || !json.get("results").isJsonArray()) {
+			throw new MediaImportException("Invalid response from TMDb API: missing 'results' array");
+		}
+
+		final List<SearchResult> results = new ArrayList<>();
+
+		final JsonArray resultsArray = json.getAsJsonArray("results");
+		for (JsonElement seriesElement : resultsArray) {
+			if (!seriesElement.isJsonObject()) {
+				continue;
+			}
+			final JsonObject seriesObject = seriesElement.getAsJsonObject();
+			if (!seriesObject.has("id") || !seriesObject.has("title")) {
+				continue;
+			}
+			final int id = seriesObject.get("id").getAsInt();
+			final String title = seriesObject.get("title").getAsString();
+			results.add(new SearchResult(id, title, MediaType.SERIES));
+		}
+
+		return results;
+	}
+
+	public List<SearchResult> searchMedia(String query, Language language) throws MediaImportException {
+		final JsonObject json = client.get("search/multi", language, Map.of("query", query));
+
+		if (!json.has("results") || !json.get("results").isJsonArray()) {
+			throw new MediaImportException("Invalid response from TMDb API: missing 'results' array");
+		}
+
+		final List<SearchResult> results = new ArrayList<>();
+
+		final JsonArray resultsArray = json.getAsJsonArray("results");
+		for (JsonElement mediaElement : resultsArray) {
+			if (!mediaElement.isJsonObject()) {
+				continue;
+			}
+			final JsonObject mediaObject = mediaElement.getAsJsonObject();
+			if (!mediaObject.has("id") || !mediaObject.has("title") || !mediaObject.has("media_type")) {
+				continue;
+			}
+			final String mediaTypeString = mediaObject.get("media_type").getAsString();
+			final MediaType mediaType = switch (mediaTypeString) {
+				case "movie" -> MediaType.MOVIE;
+				case "tv" -> MediaType.SERIES;
+				default -> null;
+			};
+			if (mediaType == null) {
+				continue;
+			}
+			final int id = mediaObject.get("id").getAsInt();
+			final String title = mediaObject.get("title").getAsString();
+			results.add(new SearchResult(id, title, mediaType));
+		}
+
+		return results;
+	}
+
+}

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
@@ -18,91 +18,61 @@ public class TmdbSearcher {
 
 	public record SearchResult(int id, String title, MediaType type) {}
 
-	public List<SearchResult> searchMovies(String query, Language language) throws MediaImportException {
-		final JsonObject json = client.get("search/movie", language, Map.of("query", query));
+	private List<SearchResult> executeSearchRequest(String endpoint, String query, Language language, java.util.function.Function<JsonObject, MediaType> mediaTypeExtractor) throws MediaImportException {
+		final JsonObject json = client.get(endpoint, language, Map.of("query", query));
 
 		if (!json.has("results") || !json.get("results").isJsonArray()) {
 			throw new MediaImportException("Invalid response from TMDb API: missing 'results' array");
 		}
 
 		final List<SearchResult> results = new ArrayList<>();
-
 		final JsonArray resultsArray = json.getAsJsonArray("results");
-		for (JsonElement movieElement : resultsArray) {
-			if (!movieElement.isJsonObject()) {
+
+		for (JsonElement searchElement : resultsArray) {
+			if (!searchElement.isJsonObject()) {
 				continue;
 			}
-			final JsonObject movieObject = movieElement.getAsJsonObject();
-			if (!movieObject.has("id") || !movieObject.has("title")) {
+
+			final JsonObject searchResultObject = searchElement.getAsJsonObject();
+			if (!searchResultObject.has("id") || !searchResultObject.has("title")) {
 				continue;
 			}
-			final int id = movieObject.get("id").getAsInt();
-			final String title = movieObject.get("title").getAsString();
-			results.add(new SearchResult(id, title, MediaType.MOVIE));
+
+			final MediaType mediaType = mediaTypeExtractor.apply(searchResultObject);
+			if (mediaType == null) {
+				continue;
+			}
+
+			final int identifier = searchResultObject.get("id").getAsInt();
+			final String title = searchResultObject.get("title").getAsString();
+
+			results.add(new SearchResult(identifier, title, mediaType));
 		}
 
 		return results;
+	}
+
+	public List<SearchResult> searchMovies(String query, Language language) throws MediaImportException {
+		return executeSearchRequest("search/movie", query, language, _ -> MediaType.MOVIE);
 	}
 
 	public List<SearchResult> searchSeries(String query, Language language) throws MediaImportException {
-		final JsonObject json = client.get("search/series", language, Map.of("query", query));
-
-		if (!json.has("results") || !json.get("results").isJsonArray()) {
-			throw new MediaImportException("Invalid response from TMDb API: missing 'results' array");
-		}
-
-		final List<SearchResult> results = new ArrayList<>();
-
-		final JsonArray resultsArray = json.getAsJsonArray("results");
-		for (JsonElement seriesElement : resultsArray) {
-			if (!seriesElement.isJsonObject()) {
-				continue;
-			}
-			final JsonObject seriesObject = seriesElement.getAsJsonObject();
-			if (!seriesObject.has("id") || !seriesObject.has("title")) {
-				continue;
-			}
-			final int id = seriesObject.get("id").getAsInt();
-			final String title = seriesObject.get("title").getAsString();
-			results.add(new SearchResult(id, title, MediaType.SERIES));
-		}
-
-		return results;
+		return executeSearchRequest("search/series", query, language, _ -> MediaType.SERIES);
 	}
 
 	public List<SearchResult> searchMedia(String query, Language language) throws MediaImportException {
-		final JsonObject json = client.get("search/multi", language, Map.of("query", query));
-
-		if (!json.has("results") || !json.get("results").isJsonArray()) {
-			throw new MediaImportException("Invalid response from TMDb API: missing 'results' array");
-		}
-
-		final List<SearchResult> results = new ArrayList<>();
-
-		final JsonArray resultsArray = json.getAsJsonArray("results");
-		for (JsonElement mediaElement : resultsArray) {
-			if (!mediaElement.isJsonObject()) {
-				continue;
+		return executeSearchRequest("search/multi", query, language, searchResultObject -> {
+			if (!searchResultObject.has("media_type")) {
+				return null;
 			}
-			final JsonObject mediaObject = mediaElement.getAsJsonObject();
-			if (!mediaObject.has("id") || !mediaObject.has("title") || !mediaObject.has("media_type")) {
-				continue;
-			}
-			final String mediaTypeString = mediaObject.get("media_type").getAsString();
-			final MediaType mediaType = switch (mediaTypeString) {
+
+			final String mediaTypeString = searchResultObject.get("media_type").getAsString();
+			return switch (mediaTypeString) {
 				case "movie" -> MediaType.MOVIE;
 				case "tv" -> MediaType.SERIES;
 				default -> null;
 			};
-			if (mediaType == null) {
-				continue;
-			}
-			final int id = mediaObject.get("id").getAsInt();
-			final String title = mediaObject.get("title").getAsString();
-			results.add(new SearchResult(id, title, mediaType));
-		}
-
-		return results;
+		});
 	}
 
 }

--- a/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
+++ b/src/main/java/de/unistuttgart/einf/moviemanager/dbimport/TmdbSearcher.java
@@ -9,14 +9,30 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A helper class to search for media on TMDb.
+ */
 public class TmdbSearcher {
 
 	private final TmdbClient client;
 
+	/**
+	 * Constructs a new searcher with the given TMDb client.
+	 *
+	 * @param client the client
+	 */
 	public TmdbSearcher(TmdbClient client) {
 		this.client = client;
 	}
 
+	/**
+	 * Represents a search result from TMDb.
+	 *
+	 * @param id the TMDb ID of the media
+	 * @param title the title
+	 * @param type the media type (movie or series)
+	 * @param releaseDate the release date (for movies) or first air date (for series), can be null if not available
+	 */
 	public record SearchResult(int id, String title, MediaType type, LocalDate releaseDate) {}
 
 	private List<SearchResult> executeSearchRequest(String endpoint, String query, Language language, java.util.function.Function<JsonObject, MediaType> mediaTypeExtractor) throws MediaImportException {
@@ -62,14 +78,38 @@ public class TmdbSearcher {
 		return results;
 	}
 
+	/**
+	 * Searches for movies on TMDb matching the given query and language.
+	 *
+	 * @param query the search query
+	 * @param language the language
+	 * @return a list of search results matching the query
+	 * @throws MediaImportException if the search request fails or the response is invalid
+	 */
 	public List<SearchResult> searchMovies(String query, Language language) throws MediaImportException {
 		return executeSearchRequest("search/movie", query, language, _ -> MediaType.MOVIE);
 	}
 
+	/**
+	 * Searches for series on TMDb matching the given query and language.
+	 *
+	 * @param query the search query
+	 * @param language the language
+	 * @return a list of search results matching the query
+	 * @throws MediaImportException if the search request fails or the response is invalid
+	 */
 	public List<SearchResult> searchSeries(String query, Language language) throws MediaImportException {
 		return executeSearchRequest("search/series", query, language, _ -> MediaType.SERIES);
 	}
 
+	/**
+	 * Searches for movies and series on TMDb matching the given query and language.
+	 *
+	 * @param query the search query
+	 * @param language the language
+	 * @return a list of search results matching the query
+	 * @throws MediaImportException if the search request fails or the response is invalid
+	 */
 	public List<SearchResult> searchMedia(String query, Language language) throws MediaImportException {
 		return executeSearchRequest("search/multi", query, language, searchResultObject -> {
 			if (!searchResultObject.has("media_type")) {


### PR DESCRIPTION
Resolves #15.

### Description

This PR extends the `import` command in order to allow searching through TMDb directly: `import search [movie|series] <query>`.

Using this subcommand leads to a popover in which the user can select the desired movie/series and import it without ever leaving the application.